### PR TITLE
fix: generate middleware when ingress is enabled

### DIFF
--- a/templates/middleware/ipwhitelistTemplate.yaml
+++ b/templates/middleware/ipwhitelistTemplate.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.traefik.enabled) (.Values.ingress.enabled) }}
+{{- if .Values.ingress.enabled }}
   {{- range $ingress_key, $ingress_val := .Values.ingress }}
     {{- if kindIs "map" $ingress_val }}
       {{- if hasKey $ingress_val "ipWhiteListMiddleware" }}


### PR DESCRIPTION
Generate ipwhitelist middlewares always when ingress is enabled, because IngressClass is hardcoded anyway to `traefik`.